### PR TITLE
init.rc: don't start console unless asked to

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -712,6 +712,8 @@ on property:ro.debuggable=1
     # Give writes to anyone for the trace folder on debug builds.
     # The folder is used to store method traces.
     chmod 0773 /data/misc/trace
+
+on property:ro.console.enable=1
     start console
 
 service flash_recovery /system/bin/install-recovery.sh


### PR DESCRIPTION
This can have a major impact on performance.

We don't want this, even on userdebug/eng builds.

Use the new property "ro.console.enable" to
enable the console service explicitly.

Change-Id: I93e7c65e92261443d1c9c70cfef9aa2ed5ff328a
Signed-off-by: Alex Naidis <alex.naidis@linux.com>